### PR TITLE
:fire: Fixed debounce method behavior

### DIFF
--- a/SIZES.md
+++ b/SIZES.md
@@ -38,7 +38,7 @@
 | countBy | 111 B | 1437 B | -1326 B |
 | curry | 290 B | 550 B | -260 B |
 | curryN | 268 B | 527 B | -259 B |
-| debounce | 132 B | n/a B | n/a B |
+| debounce | 129 B | n/a B | n/a B |
 | dec | 32 B | 252 B | -220 B |
 | descend | 57 B | 356 B | -299 B |
 | difference | 415 B | 1561 B | -1146 B |

--- a/SIZES.md
+++ b/SIZES.md
@@ -38,7 +38,7 @@
 | countBy | 111 B | 1437 B | -1326 B |
 | curry | 290 B | 550 B | -260 B |
 | curryN | 268 B | 527 B | -259 B |
-| debounce | 72 B | n/a B | n/a B |
+| debounce | 132 B | n/a B | n/a B |
 | dec | 32 B | 252 B | -220 B |
 | descend | 57 B | 356 B | -299 B |
 | difference | 415 B | 1561 B | -1146 B |

--- a/lib/debounce/index.js
+++ b/lib/debounce/index.js
@@ -1,3 +1,10 @@
+/**
+ * Debounce
+ * @param {number} time Time in ms
+ * @param {Function} fn Function that need to be debounced
+ * @param {Object} options Options object
+ * @param {boolean} [options.leading=true] When true, fn will be called on the leading edge, otherwise - after timeout
+ */
 export default function debounce(time, fn, opts) {
   opts = opts || {}
   var timer = null

--- a/lib/debounce/index.js
+++ b/lib/debounce/index.js
@@ -1,15 +1,40 @@
-export default function debounce(time, fn) {
-  var isCalling = false
-  return function() {
-    if (isCalling) return;
-    isCalling = true
-    setTimeout(
-      function() {
-        fn.apply(fn, arguments)
-        isCalling = false
-      },
-      time,
-      arguments
-    )
+export default function debounce(time, fn, opts) {
+  opts = opts || {}
+  var timer = null
+
+  function call(args) {
+    timer = setTimeout(function() {
+      fn.apply(fn, args)
+      timer = null
+    }, time)
   }
+
+  function clear() {
+    timer = setTimeout(run.cancel, time)
+  }
+
+  function run() {
+    if (!timer) {
+      if (opts.leading) {
+        fn.apply(fn, arguments)
+        clear()
+      } else {
+        call(arguments)
+      }
+    } else {
+      clearTimeout(timer)
+      if (opts.leading) {
+        clear()
+      } else {
+        call(arguments)
+      }
+    }
+  }
+
+  run.cancel = function() {
+    clearTimeout(timer)
+    timer = null
+  }
+
+  return run
 }

--- a/lib/debounce/index.js
+++ b/lib/debounce/index.js
@@ -23,11 +23,7 @@ export default function debounce(time, fn, opts) {
       }
     } else {
       clearTimeout(timer)
-      if (opts.leading) {
-        clear()
-      } else {
-        call(arguments)
-      }
+      call(arguments)
     }
   }
 


### PR DESCRIPTION
Related to https://github.com/Kelin2025/nanoutils/issues/33 issue
I haven't tested it yet because I don't completely understand all cases.  
Check whether it's correct behaviour:
- When `leading: true`:
  - When timer is not set, call and set timer with just clear
  - When timer is set, clear it and restart again (without call)
- When `leading: false`:
  - When timer is not set, set timer and call after it
  - When timer is set, clear it and set timer again  
Also I added `.cancel()` method that just clears timer  

