### PR TITLE
Fix cli sizes table formatting

### DIFF
--- a/SIZES.md
+++ b/SIZES.md
@@ -133,7 +133,7 @@
 | toPairs | 62 B | 189 B | -127 B |
 | toPairsIn | 90 B | 166 B | -76 B |
 | transpose | 104 B | 204 B | -100 B |
-| tryCatch | 114 B | 487 B | -373 B |
+| tryCatch | 106 B | 487 B | -381 B |
 | unapply | 301 B | 161 B | +140 B |
 | unary | 35 B | 430 B | -395 B |
 | unfold | 110 B | 266 B | -156 B |

--- a/misc/cli/size.js
+++ b/misc/cli/size.js
@@ -11,7 +11,7 @@ const readdir = util.promisify(fs.readdir)
 const writeFile = util.promisify(fs.writeFile)
 const createRow = cols => '║ ' + cols.join(' ║ ') + ' ║'
 const formatName = name => chalk.bold(name.padEnd(longestName))
-const formatSize = size => `${size}`.padStart(5) + ' B'
+const formatSize = size => `${size}`.padStart(6) + ' B'
 const getDiff = (size, ramdaSize) =>
   ramdaSize === 'n/a'
     ? 'n/a'
@@ -89,7 +89,7 @@ Promise
   })
   // Draw table
   .then(methods => {
-    const lens = [longestName + 2, 9, 9, 10]
+    const lens = [longestName + 2, 10, 10, 10]
     const sline = lens.map(len => '─'.repeat(len))
     const dline = lens.map(len => '═'.repeat(len))
     const topper = `╔${dline.join('╦')}╗`
@@ -97,8 +97,8 @@ Promise
     const bottom = `╚${dline.join('╩')}╝`
     const header = createRow([
       formatName('Method'),
-      chalk.bold('Nano'.padStart(7)),
-      chalk.bold('Ramda'.padStart(7)),
+      chalk.bold('Nano'.padStart(8)),
+      chalk.bold('Ramda'.padStart(8)),
       chalk.bold('Diff'.padStart(8))
     ])
     const content = methods.map(i => i.border).join('\n')


### PR DESCRIPTION
Now:
<img width="300" alt="aleksandrbabkin_aleksandrs-macbook-pro____documents_nanoutils__zsh_" src="https://user-images.githubusercontent.com/25172855/36887780-c179e380-1e03-11e8-82b3-5ba3b80e301d.png">

Was:
<img width="300" alt="aleksandrbabkin_aleksandrs-macbook-pro____documents_nanoutils__zsh_" src="https://user-images.githubusercontent.com/25172855/36887806-dd2f1118-1e03-11e8-9de7-915bf5a6bca2.png">
