### PR TITLE
Fixed 'add-method' cli command: parse flags and curring. Fixed readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want to help, here are some tools for you.
 ### Shortcut for new methods
 
 ```
-npm add-method <...methods> [flags]
+npm run method:add <...methods> -- [flags]
 
 Params:
     methods           List with method names (separated by space)

--- a/SIZES.md
+++ b/SIZES.md
@@ -133,7 +133,7 @@
 | toPairs | 62 B | 189 B | -127 B |
 | toPairsIn | 90 B | 166 B | -76 B |
 | transpose | 104 B | 204 B | -100 B |
-| tryCatch | 114 B | 487 B | -373 B |
+| tryCatch | 106 B | 487 B | -381 B |
 | unapply | 301 B | 161 B | +140 B |
 | unary | 35 B | 430 B | -395 B |
 | unfold | 110 B | 266 B | -156 B |

--- a/misc/cli/add-method.js
+++ b/misc/cli/add-method.js
@@ -3,7 +3,8 @@ const path = require('path')
 const chalk = require('chalk')
 const minimist = require('minimist')
 
-const args = minimist(process.argv.slice(2))
+const args = minimist(process.argv.slice(2), { alias: { f: 'force' } })
+
 const names = args._
 
 const methodPath = name => path.resolve('lib', name)
@@ -18,11 +19,28 @@ export default curry(function ${name}() {
 
 })`
 
-const curriedNumMethodTemplate = (name, num) => `import curryN from '../curryN'
+const curriedNumMethodTemplate = (name, num) => {
+
+	const curried = {
+		2: `import _curry2 from '../_internal/_curry2'
+
+export default _curry2(function ${name}() {
+
+})`,
+3: `import _curry3 from '../_internal/_curry3'
+
+export default _curry3(function ${name}() {
+
+})`,
+		n: `import curryN from '../curryN'
 
 export default curryN(${num}, function ${name}() {
 
 })`
+	}
+
+	return !!curried[num] ? curried[num] : curried.n
+}
 
 const tsTemplate = name => `export default function ${name}(): void`
 


### PR DESCRIPTION
Now force flag `-f` parsing properly. 
Also added usage of internal `curry` methods