### PR TITLE
New methods: split (Size: 86 B), splitAt (Size: 93 B), splitEvery (Size: 118 B), splitWhen (Size: 124 B)

### DIFF
--- a/SIZES.md
+++ b/SIZES.md
@@ -120,6 +120,10 @@
 | set | 111 B | 411 B | -300 B |
 | sortBy | 91 B | 273 B | -182 B |
 | sortWith | 144 B | 285 B | -141 B |
+| split | 28 B | 3344 B | -3316 B |
+| splitAt | 28 B | 556 B | -528 B |
+| splitEvery | 28 B | 592 B | -564 B |
+| splitWhen | 124 B | 284 B | -160 B |
 | subtract | 82 B | 240 B | -158 B |
 | sum | 43 B | 1069 B | -1026 B |
 | T | 53 B | 156 B | -103 B |

--- a/SIZES.md
+++ b/SIZES.md
@@ -121,8 +121,8 @@
 | sortBy | 91 B | 273 B | -182 B |
 | sortWith | 144 B | 285 B | -141 B |
 | split | 86 B | 3344 B | -3258 B |
-| splitAt | 28 B | 556 B | -528 B |
-| splitEvery | 28 B | 592 B | -564 B |
+| splitAt | 93 B | 556 B | -463 B |
+| splitEvery | 80 B | 592 B | -512 B |
 | splitWhen | 124 B | 284 B | -160 B |
 | subtract | 82 B | 240 B | -158 B |
 | sum | 43 B | 1069 B | -1026 B |

--- a/SIZES.md
+++ b/SIZES.md
@@ -120,7 +120,7 @@
 | set | 111 B | 411 B | -300 B |
 | sortBy | 91 B | 273 B | -182 B |
 | sortWith | 144 B | 285 B | -141 B |
-| split | 28 B | 3344 B | -3316 B |
+| split | 86 B | 3344 B | -3258 B |
 | splitAt | 28 B | 556 B | -528 B |
 | splitEvery | 28 B | 592 B | -564 B |
 | splitWhen | 124 B | 284 B | -160 B |

--- a/SIZES.md
+++ b/SIZES.md
@@ -122,7 +122,7 @@
 | sortWith | 144 B | 285 B | -141 B |
 | split | 86 B | 3344 B | -3258 B |
 | splitAt | 93 B | 556 B | -463 B |
-| splitEvery | 80 B | 592 B | -512 B |
+| splitEvery | 118 B | 592 B | -474 B |
 | splitWhen | 124 B | 284 B | -160 B |
 | subtract | 82 B | 240 B | -158 B |
 | sum | 43 B | 1069 B | -1026 B |

--- a/lib/split/index.js
+++ b/lib/split/index.js
@@ -1,0 +1,5 @@
+import _curry2 from '../_internal/_curry2'
+
+export default _curry2(function split(separator, str) {
+  return str.split(separator)
+})

--- a/lib/split/split.test.js
+++ b/lib/split/split.test.js
@@ -1,0 +1,11 @@
+import split from '.'
+
+test('separates a string by separator', () => {
+  expect(split('/', '/usr/local/bin/node')).toEqual([
+    '',
+    'usr',
+    'local',
+    'bin',
+    'node'
+  ])
+})

--- a/lib/splitAt/index.js
+++ b/lib/splitAt/index.js
@@ -1,0 +1,5 @@
+import _curry2 from '../_internal/_curry2'
+
+export default _curry2(function splitAt(pos, list) {
+  return [list.slice(0, pos), list.slice(pos)]
+})

--- a/lib/splitAt/splitAt.test.js
+++ b/lib/splitAt/splitAt.test.js
@@ -1,0 +1,13 @@
+import splitAt from '.'
+
+test('splits a given list at a given index', () => {
+  expect(splitAt(1, [1, 2, 3])).toEqual([[1], [2, 3]])
+})
+
+test('works with string', () => {
+  expect(splitAt(5, 'hello world')).toEqual(['hello', ' world'])
+})
+
+test('works with negative keys', () => {
+  expect(splitAt(-1, 'foobar')).toEqual(['fooba', 'r'])
+})

--- a/lib/splitEvery/index.js
+++ b/lib/splitEvery/index.js
@@ -1,0 +1,9 @@
+import _curry2 from '../_internal/_curry2'
+
+export default _curry2(function splitEvery(num, arr) {
+  var res = []
+  for (var i = 0; i < arr.length; i += num) {
+    res.push(arr.slice(i, i + num))
+  }
+  return res
+})

--- a/lib/splitEvery/splitEvery.test.js
+++ b/lib/splitEvery/splitEvery.test.js
@@ -1,0 +1,13 @@
+import splitEvery from '.'
+
+test('splits a list into slices of specified length', () => {
+  expect(splitEvery(3, [1, 2, 3, 4, 5, 6, 7])).toEqual([
+    [1, 2, 3],
+    [4, 5, 6],
+    [7]
+  ])
+})
+
+test('works with strings', () => {
+  expect(splitEvery(3, 'foobarbaz')).toEqual(['foo', 'bar', 'baz'])
+})

--- a/lib/splitWhen/index.js
+++ b/lib/splitWhen/index.js
@@ -1,0 +1,10 @@
+import _curry2 from '../_internal/_curry2'
+
+export default _curry2(function splitWhen(cb, arr) {
+  var left = []
+  while (left.length < arr.length) {
+    if (cb(arr[left.length])) break
+    left.push(arr[left.length])
+  }
+  return [left, arr.slice(left.length)]
+})

--- a/lib/splitWhen/splitWhen.test.js
+++ b/lib/splitWhen/splitWhen.test.js
@@ -1,0 +1,8 @@
+import splitWhen from '.'
+
+test('no tests yet', () => {
+  expect(splitWhen(i => i === 3, [1, 2, 3, 1, 2, 3])).toEqual([
+    [1, 2],
+    [3, 1, 2, 3]
+  ])
+})


### PR DESCRIPTION
[`R.split`](http://ramdajs.com/docs/#split)  
[`R.splitAt`](http://ramdajs.com/docs/#splitAt)  
[`R.splitWhen`](http://ramdajs.com/docs/#splitWhen)  
[`R.splitEvery`](http://ramdajs.com/docs/#splitEvery)  
@Beraliv performance tests? :smirk: 