### PR TITLE
Fix: lensPath

### DIFF
--- a/SIZES.md
+++ b/SIZES.md
@@ -19,7 +19,7 @@
 | applySpec | 351 B | 2075 B | -1724 B |
 | applyTo | 81 B | 228 B | -147 B |
 | ascend | 57 B | 356 B | -299 B |
-| assoc | 581 B | 361 B | +220 B |
+| assoc | 530 B | 361 B | +169 B |
 | az | 51 B | n/a B | n/a B |
 | binary | 37 B | 430 B | -393 B |
 | both | 48 B | 1944 B | -1896 B |
@@ -79,7 +79,7 @@
 | last | 37 B | 302 B | -265 B |
 | lastIndexOf | 115 B | 1462 B | -1347 B |
 | lens | 301 B | 1745 B | -1444 B |
-| lensPath | 473 B | 2095 B | -1622 B |
+| lensPath | 424 B | 2095 B | -1671 B |
 | lt | 82 B | 230 B | -148 B |
 | lte | 83 B | 231 B | -148 B |
 | map | 122 B | 1710 B | -1588 B |
@@ -103,7 +103,7 @@
 | omit | 129 B | 285 B | -156 B |
 | omitBy | 116 B | n/a B | n/a B |
 | or | 82 B | 231 B | -149 B |
-| over | 588 B | 364 B | +224 B |
+| over | 537 B | 364 B | +173 B |
 | partial | 94 B | 497 B | -403 B |
 | partialRight | 94 B | 704 B | -610 B |
 | pick | 102 B | 266 B | -164 B |
@@ -111,7 +111,7 @@
 | pipe | 141 B | 1245 B | -1104 B |
 | pipeP | 150 B | 1260 B | -1110 B |
 | product | 41 B | 1061 B | -1020 B |
-| prop | 556 B | 286 B | +270 B |
+| prop | 506 B | 286 B | +220 B |
 | reduce | 261 B | 1021 B | -760 B |
 | reduceRight | 147 B | 361 B | -214 B |
 | reject | 140 B | 1575 B | -1435 B |
@@ -159,7 +159,7 @@
 | za | 53 B | n/a B | n/a B |
 | zip | 183 B | 273 B | -90 B |
 | zipObj | 49 B | 271 B | -222 B |
-| zipObjDeep | 600 B | n/a B | n/a B |
+| zipObjDeep | 548 B | n/a B | n/a B |
 | zipWith | 165 B | 383 B | -218 B |
 ## How it works?
 We use [size-limit](https://github.com/ai/size-limit) to check methods size

--- a/lib/assoc/assoc.test.js
+++ b/lib/assoc/assoc.test.js
@@ -1,10 +1,10 @@
-import assoc from '.';
+import assoc from '.'
 
 test('sets value by its path', () => {
-  expect(assoc('a.b', 3, { a: { b: 2 } })).toEqual({ a: { b: 3 } })
+  expect(assoc(['a', 'b'], 3, { a: { b: 2 } })).toEqual({ a: { b: 3 } })
 })
 
 test('works correctly for arrays', () => {
-  const val = assoc(0, 11, [1, 2, 3])
+  const val = assoc([0], 11, [1, 2, 3])
   expect(val).toEqual([11, 2, 3])
 })

--- a/lib/az/az.test.js
+++ b/lib/az/az.test.js
@@ -5,5 +5,10 @@ import sortBy from '../sortBy'
 test('can be used with prop and sortBy', () => {
   const array = [{ a: 'z' }, { a: 'y' }, { a: 'x' }, { a: 'w' }]
 
-  expect(sortBy(az(prop('a')), array)).toEqual([{ a: 'w' }, { a: 'x' }, { a: 'y' }, { a: 'z' }])
+  expect(sortBy(az(prop(['a'])), array)).toEqual([
+    { a: 'w' },
+    { a: 'x' },
+    { a: 'y' },
+    { a: 'z' }
+  ])
 })

--- a/lib/lensPath/index.js
+++ b/lib/lensPath/index.js
@@ -1,8 +1,6 @@
-import p2a from '../_internal/_p2a'
 import lens from '../lens'
 
-export default function lensPath(k) {
-  var p = p2a(k)
+export default function lensPath(p) {
   return lens(
     function propGetter(obj) {
       return p.reduce(function(val, k) {

--- a/lib/lensPath/lensPath.test.js
+++ b/lib/lensPath/lensPath.test.js
@@ -9,45 +9,43 @@ var obj = {
 
 var arr = [1, 2, 3]
 
-var lensBC = lensPath('b.c')
-
 test('getter returns object value by key getter', () => {
-  const lensBC = lensPath('b.c')(obj)
+  const lensBC = lensPath(['b', 'c'])(obj)
   expect(lensBC.get()).toBe(3)
 })
 
 test('getter returns undefined for non-objects', () => {
-  const lensBC = lensPath('b.c')(undefined)
+  const lensBC = lensPath(['b', 'c'])(undefined)
   expect(lensBC.get()).toBe(undefined)
 })
 
 test('getter returns undefined for non-existent paths', () => {
-  const lensBC = lensPath('b.c.d')(obj)
+  const lensBC = lensPath(['b', 'c', 'd'])(obj)
   expect(lensBC.get()).toBe(undefined)
 })
 
 test('getter returns value from array', () => {
-  const lens0 = lensPath(0)(arr)
+  const lens0 = lensPath([0])(arr)
   expect(lens0.get()).toBe(1)
 })
 
 test('setter sets value', () => {
-  const lensD = lensPath('b.c.d')({ a: { b: 2 } })
+  const lensD = lensPath(['b', 'c', 'd'])({ a: { b: 2 } })
   expect(lensD.set(3)).toEqual({ a: { b: 2 }, b: { c: { d: 3 } } })
 })
 
 test('setter overwrites properties', () => {
-  const lensBC = lensPath('b.c')(obj)
+  const lensBC = lensPath(['b', 'c'])(obj)
   expect(lensBC.set(2)).toEqual({ a: 2, b: { c: 2 } })
 })
 
 test("setter sets nested value even if it's already declared or undefined", () => {
-  const lensA = lensPath('a.b.c')({ a: { b: 2 } })
+  const lensA = lensPath(['a', 'b', 'c'])({ a: { b: 2 } })
   expect(lensA.set(3)).toEqual({ a: { b: { c: 3 } } })
 })
 
 test('setter adds array items if key is numeric', () => {
-  const lensB = lensPath('a.b.1')({ a: { b: [2] } })
+  const lensB = lensPath(['a', 'b', '1'])({ a: { b: [2] } })
   expect(lensB.set(3)).toEqual({ a: { b: [2, 3] } })
 })
 
@@ -55,11 +53,11 @@ test('setter adds properties for non-plain objects', () => {
   const arrWithTest = [2]
   arrWithTest.test = 3
 
-  const lensC = lensPath('a.b.test')({ a: { b: [2] } })
+  const lensC = lensPath(['a', 'b', 'test'])({ a: { b: [2] } })
   expect(lensC.set(3).a.b).toEqual(arrWithTest)
 })
 
 test('setter adds value to array', () => {
-  const lens0 = lensPath(0)(arr)
+  const lens0 = lensPath([0])(arr)
   expect(lens0.set(11)).toEqual([11, 2, 3])
 })

--- a/lib/over/over.test.js
+++ b/lib/over/over.test.js
@@ -1,13 +1,13 @@
 import over from '.'
 
 test('updates value by its path', () => {
-  const val = over('a.b', i => i + 1, { a: { b: 2 } })
+  const val = over(['a', 'b'], i => i + 1, { a: { b: 2 } })
   expect(val).toEqual({
     a: { b: 3 }
   })
 })
 
 test('works correctly for arrays', () => {
-  const val = over(0, i => i + 10, [1, 2, 3])
+  const val = over([0], i => i + 10, [1, 2, 3])
   expect(val).toEqual([11, 2, 3])
 })

--- a/lib/prop/prop.test.js
+++ b/lib/prop/prop.test.js
@@ -1,10 +1,10 @@
 var prop = require('.')
 
 test('returns value by its path', () => {
-  expect(prop('a.b', { a: { b: 3 } })).toBe(3)
+  expect(prop(['a', 'b'], { a: { b: 3 } })).toBe(3)
 })
 
 test('works correctly for arrays', () => {
-  var val = prop(0, [1, 2, 3])
+  var val = prop([0], [1, 2, 3])
   expect(val).toEqual(1)
 })

--- a/lib/sortBy/sortBy.test.js
+++ b/lib/sortBy/sortBy.test.js
@@ -20,7 +20,7 @@ test('can compare primitives', () => {
   expect(sort(arrayOfBooleans)).toEqual([false, false, false, true, true])
 })
 
-test('doesn\'t mutate original array', () => {
+test("doesn't mutate original array", () => {
   const array = [5, 4, 3, 2, 1]
 
   sortBy(less, array)
@@ -31,23 +31,47 @@ test('doesn\'t mutate original array', () => {
 test('can use ascend and prop to compare object-elements', () => {
   const array = [{ a: 5 }, { a: 4 }, { a: 3 }, { a: 2 }, { a: 1 }]
 
-  expect(sortBy(ascend(prop('a')), array)).toEqual([{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 }])
+  expect(sortBy(ascend(prop(['a'])), array)).toEqual([
+    { a: 1 },
+    { a: 2 },
+    { a: 3 },
+    { a: 4 },
+    { a: 5 }
+  ])
 })
 
 test('can use descend and prop to compare object-elements', () => {
   const array = [{ a: 1 }, { a: 2 }, { a: 3 }, { a: 4 }, { a: 5 }]
 
-  expect(sortBy(descend(prop('a')), array)).toEqual([{ a: 5 }, { a: 4 }, { a: 3 }, { a: 2 }, { a: 1 }])
+  expect(sortBy(descend(prop(['a'])), array)).toEqual([
+    { a: 5 },
+    { a: 4 },
+    { a: 3 },
+    { a: 2 },
+    { a: 1 }
+  ])
 })
 
 test('can use az and prop to compare object-elements', () => {
   const array = [{ a: 'z' }, { a: 'y' }, { a: 'x' }, { a: 'w' }, { a: 'v' }]
 
-  expect(sortBy(az(prop('a')), array)).toEqual([{ a: 'v' }, { a: 'w' }, { a: 'x' }, { a: 'y' }, { a: 'z' }])
+  expect(sortBy(az(prop(['a'])), array)).toEqual([
+    { a: 'v' },
+    { a: 'w' },
+    { a: 'x' },
+    { a: 'y' },
+    { a: 'z' }
+  ])
 })
 
 test('can use za and prop to compare object-elements', () => {
   const array = [{ a: 'v' }, { a: 'w' }, { a: 'x' }, { a: 'y' }, { a: 'z' }]
 
-  expect(sortBy(za(prop('a')), array)).toEqual([{ a: 'z' }, { a: 'y' }, { a: 'x' }, { a: 'w' }, { a: 'v' }])
+  expect(sortBy(za(prop(['a'])), array)).toEqual([
+    { a: 'z' },
+    { a: 'y' },
+    { a: 'x' },
+    { a: 'w' },
+    { a: 'v' }
+  ])
 })

--- a/lib/sortWith/sortWith.test.js
+++ b/lib/sortWith/sortWith.test.js
@@ -6,8 +6,8 @@ import sortBy from '../sortBy'
 test('equals to sortBy if the number of comparators equals 1', () => {
   const array = [{ b: 4 }, { b: 3 }, { b: 2 }, { b: 1 }]
 
-  const sortByArray = sortBy(ascend(prop('b')), array)
-  const sortWithOneComparator = sortWith([ascend(prop('b'))], array)
+  const sortByArray = sortBy(ascend(prop(['b'])), array)
+  const sortWithOneComparator = sortWith([ascend(prop(['b']))], array)
 
   expect(sortByArray).toEqual(sortWithOneComparator)
 })
@@ -15,8 +15,15 @@ test('equals to sortBy if the number of comparators equals 1', () => {
 test('compares with several comparators', () => {
   const array = [{ a: 4, z: 3 }, { a: 3, z: 3 }, { a: 2, z: 2 }, { a: 1, z: 2 }]
 
-  const sortWithSeveralComparators = sortWith([ascend(prop('z')), ascend(prop('a'))])
+  const sortWithSeveralComparators = sortWith([
+    ascend(prop(['z'])),
+    ascend(prop(['a']))
+  ])
 
-  expect(sortWithSeveralComparators(array))
-    .toEqual([{ a: 1, z: 2 }, { a: 2, z: 2 }, { a: 3, z: 3 }, { a: 4, z: 3 }])
+  expect(sortWithSeveralComparators(array)).toEqual([
+    { a: 1, z: 2 },
+    { a: 2, z: 2 },
+    { a: 3, z: 3 },
+    { a: 4, z: 3 }
+  ])
 })

--- a/lib/za/za.test.js
+++ b/lib/za/za.test.js
@@ -5,5 +5,10 @@ import prop from '../prop'
 it('can be used with prop and sortBy', () => {
   const array = [{ a: 'w' }, { a: 'x' }, { a: 'y' }, { a: 'z' }]
 
-  expect(sortBy(za(prop('a')), array)).toEqual([{ a: 'z' }, { a: 'y' }, { a: 'x' }, { a: 'w' }])
+  expect(sortBy(za(prop(['a'])), array)).toEqual([
+    { a: 'z' },
+    { a: 'y' },
+    { a: 'x' },
+    { a: 'w' }
+  ])
 })

--- a/lib/zipObjDeep/zipObjDeep.test.js
+++ b/lib/zipObjDeep/zipObjDeep.test.js
@@ -1,17 +1,17 @@
 var zipObjDeep = require('.')
 
 test('creates object with paths from 1st array and values from 2nd', () => {
-  expect(zipObjDeep(['a.b', 'a.c.0'], [1, 2])).toEqual({
+  expect(zipObjDeep([['a', 'b'], ['a', 'c', '0']], [1, 2])).toEqual({
     a: { b: 1, c: [2] }
   })
 })
 
 test('ignores extra values', () => {
-  expect(zipObjDeep(['a', 'b'], [1, 2, 3])).toEqual({ a: 1, b: 2 })
+  expect(zipObjDeep([['a'], ['b']], [1, 2, 3])).toEqual({ a: 1, b: 2 })
 })
 
 test('sets undefined for extra keys', () => {
-  expect(zipObjDeep(['a', 'b', 'c'], [1, 2])).toEqual({
+  expect(zipObjDeep([['a'], ['b'], ['c']], [1, 2])).toEqual({
     a: 1,
     b: 2,
     c: undefined


### PR DESCRIPTION
Fix for lens and methods that use path logic
```javascript
/* before */
lensPath('a.b.c')

/* after */
lensPath(['a', 'b', 'c'])
```
It looks worse, but there are no possible way to write flow/ts types for the 1st notation  
Also, it saves ~50 B for each method