### PR TITLE
Fix for placehold method

### DIFF
--- a/lib/_internal/_placehold/index.js
+++ b/lib/_internal/_placehold/index.js
@@ -16,7 +16,7 @@ export default function placehold(fn, length, oldArgs) {
         length,
         oldArgs
           .reduce(function(_next, a) {
-            return _next.concat(a !== __ ? a : (newArgs.shift() || __))
+            return _next.concat([a !== __ ? a : newArgs.shift() || __])
           }, [])
           .concat(newArgs)
       )


### PR DESCRIPTION
```javascript
const a = (a,b,c,d) => console.log(a,b,c,d)

// should call function
// but instead, there are still 0 args
// before of .concat()
placehold(a)([],[],[],[]) 
```
Fixed that