### PR TITLE
New method: eqProps (107 B)

### DIFF
--- a/SIZES.md
+++ b/SIZES.md
@@ -57,6 +57,7 @@
 | either | 48 B | 1943 B | -1895 B |
 | eqBy | 385 B | 1500 B | -1115 B |
 | eqLens | 386 B | n/a B | n/a B |
+| eqProps | 107 B | 1500 B | -1393 B |
 | equals | 321 B | 1369 B | -1048 B |
 | eqWith | 103 B | n/a B | n/a B |
 | evolve | 93 B | 282 B | -189 B |
@@ -76,6 +77,8 @@
 | indexed | 40 B | n/a B | n/a B |
 | indexOf | 110 B | 1570 B | -1460 B |
 | init | 152 B | 493 B | -341 B |
+| insert | 124 B | 378 B | -254 B |
+| insertAll | 132 B | 379 B | -247 B |
 | invoker | 321 B | 3337 B | -3016 B |
 | is | 100 B | 252 B | -152 B |
 | isInteger | 48 B | n/a B | n/a B |
@@ -118,6 +121,7 @@
 | pipeP | 150 B | 1260 B | -1110 B |
 | product | 41 B | 1061 B | -1020 B |
 | prop | 506 B | 286 B | +220 B |
+| range | 108 B | 342 B | -234 B |
 | reduce | 261 B | 1021 B | -760 B |
 | reduceBy | 324 B | 1424 B | -1100 B |
 | reduceRight | 132 B | 361 B | -229 B |
@@ -126,6 +130,7 @@
 | reject | 140 B | 1575 B | -1435 B |
 | repeat | 104 B | 364 B | -260 B |
 | reverse | 91 B | 212 B | -121 B |
+| scan | 129 B | 373 B | -244 B |
 | set | 111 B | 411 B | -300 B |
 | sortBy | 91 B | 273 B | -182 B |
 | sortWith | 144 B | 285 B | -141 B |
@@ -141,6 +146,7 @@
 | takeLast | 140 B | 808 B | -668 B |
 | takeLastWhile | 140 B | 528 B | -388 B |
 | takeWhile | 135 B | 822 B | -687 B |
+| tap | 100 B | 540 B | -440 B |
 | throttle | 72 B | n/a B | n/a B |
 | times | 106 B | 326 B | -220 B |
 | toArray | 39 B | n/a B | n/a B |

--- a/lib/eqProps/eqProps.test.js
+++ b/lib/eqProps/eqProps.test.js
@@ -1,0 +1,13 @@
+import eqProps from '.'
+
+test('compares two props of objects and returns their equality', () => {
+  const common = { a: 1 }
+  const obj1 = { b: 1, c: 2, d: common, f: 3 }
+  const obj2 = { b: 1, c: 20, d: common }
+
+  expect(eqProps('b', obj1, obj2)).toBeTruthy()
+  expect(eqProps('c')(obj1, obj2)).toBeFalsy()
+  expect(eqProps('d', obj1)(obj2)).toBeTruthy()
+  expect(eqProps('f', obj1, obj2)).toBeFalsy()
+  expect(eqProps('fff', obj1, obj2)).toBeTruthy()
+})

--- a/lib/eqProps/index.js
+++ b/lib/eqProps/index.js
@@ -1,0 +1,5 @@
+import _curry3 from '../_internal/_curry3'
+
+export default _curry3(function eqProps(prop, obj1, obj2) {
+  return obj1[prop] === obj2[prop]
+})

--- a/lib/eqProps/index.js.flow
+++ b/lib/eqProps/index.js.flow
@@ -1,0 +1,2 @@
+// @flow
+declare module.exports: (prop: mixed) => (obj1: Object) => (obj2: Object) => Boolean


### PR DESCRIPTION
[Ramda's eqProps](http://ramdajs.com/docs/#eqProps)

If both objects have no provided property, method will return true, because `undefined === undefined`. It's ramda's behavior

Type-checking will be later, as discussed