### PR TITLE
New method: identical (109 B)

### DIFF
--- a/SIZES.md
+++ b/SIZES.md
@@ -78,6 +78,7 @@
 | gt | 82 B | 230 B | -148 B |
 | gte | 83 B | 231 B | -148 B |
 | head | 31 B | 301 B | -270 B |
+| identical | 109 B | 249 B | -140 B |
 | identity | 29 B | 150 B | -121 B |
 | ifElse | 110 B | 687 B | -577 B |
 | inc | 32 B | 250 B | -218 B |

--- a/lib/identical/identical.test.js
+++ b/lib/identical/identical.test.js
@@ -1,0 +1,26 @@
+import identical from '.'
+
+test('checks if two plain items are equals', () => {
+  expect(identical(1, 1)).toBeTruthy()
+  expect(identical('a', 'a')).toBeTruthy()
+  expect(identical(true, true)).toBeTruthy()
+  expect(identical(undefined, undefined)).toBeTruthy()
+  expect(identical(undefined, null)).toBeFalsy()
+  expect(identical(1, '1')).toBeFalsy()
+})
+
+test('check equality by reference for structured items', () => {
+  const obj1 = {}
+
+  expect(identical(obj1, obj1)).toBeTruthy()
+  expect(identical({}, {})).toBeFalsy()
+  expect(identical([], [])).toBeFalsy()
+})
+
+test('NaN should be equals to NaN', () => {
+  expect(identical(NaN, NaN)).toBeTruthy()
+})
+
+test('0 and -0 should not be equal', () => {
+  expect(identical(-0, 0)).toBeFalsy()
+})

--- a/lib/identical/index.js
+++ b/lib/identical/index.js
@@ -1,0 +1,7 @@
+import _curry2 from '../_internal/_curry2'
+
+export default _curry2(function identical(a, b) {
+  if (a + '' === 'NaN') return a + '' === b + ''
+  if (a === 0) return 1 / a === 1 / b
+  return a === b
+})

--- a/lib/identical/index.js.flow
+++ b/lib/identical/index.js.flow
@@ -1,0 +1,2 @@
+// @flow
+declare module.exports: (a: ?mixed) => (b: ?mixed) => boolean

--- a/misc/cli/size.js
+++ b/misc/cli/size.js
@@ -17,10 +17,10 @@ const getDiff = (size, ramdaSize) =>
     ? 'n/a'
     : `${ramdaSize >= size ? '' : '+'}${size - ramdaSize}`
 const formatDiff = (size, ramdaSize) => {
-  if (ramdaSize === 'n/a') return 'n/a'.padStart(8)
+  if (ramdaSize === 'n/a') return 'n/a'.padStart(9)
   const ok = ramdaSize >= size
   return chalk[ok ? 'green' : 'red'](
-    `${ok ? '' : '+'}${size - ramdaSize}`.padStart(6) + ' B'
+    `${ok ? '' : '+'}${size - ramdaSize}`.padStart(7) + ' B'
   )
 }
 
@@ -89,7 +89,7 @@ Promise
   })
   // Draw table
   .then(methods => {
-    const lens = [longestName + 2, 10, 10, 10]
+    const lens = [longestName + 2, 10, 10, 11]
     const sline = lens.map(len => '─'.repeat(len))
     const dline = lens.map(len => '═'.repeat(len))
     const topper = `╔${dline.join('╦')}╗`
@@ -99,7 +99,7 @@ Promise
       formatName('Method'),
       chalk.bold('Nano'.padStart(8)),
       chalk.bold('Ramda'.padStart(8)),
-      chalk.bold('Diff'.padStart(8))
+      chalk.bold('Diff'.padStart(9))
     ])
     const content = methods.map(i => i.border).join('\n')
     const total = methods.reduce(


### PR DESCRIPTION
[Ramda identical](http://ramdajs.com/docs/#identical)

Ternary notation would not decrease the size of method (even for 1 byte), but would make it not readable.

Also, I've fixed cli size table formatting:

from:
<img width="300" alt="table" src="https://user-images.githubusercontent.com/25172855/37389305-de10582e-2774-11e8-9fe8-5e35f6f69dd4.png">

to:
<img width="300" alt="aleksandrbabkin_aleksandrs-macbook-pro____documents_nanoutils_lib" src="https://user-images.githubusercontent.com/25172855/37389319-e890858a-2774-11e8-9cb5-adb7c0677110.png">
