### PR TITLE
New methods: nth (115 B), nthArg (55 B)

### DIFF
--- a/SIZES.md
+++ b/SIZES.md
@@ -136,6 +136,8 @@
 | negate | 31 B | 145 B | -114 B |
 | noop | 57 B | n/a B | n/a B |
 | not | 31 B | 144 B | -113 B |
+| nth | 115 B | 285 B | -170 B |
+| nthArg | 40 B | 633 B | -593 B |
 | objOf | 90 B | 240 B | -150 B |
 | of | 29 B | 151 B | -122 B |
 | omit | 129 B | 285 B | -156 B |

--- a/SIZES.md
+++ b/SIZES.md
@@ -137,7 +137,7 @@
 | noop | 57 B | n/a B | n/a B |
 | not | 31 B | 144 B | -113 B |
 | nth | 115 B | 285 B | -170 B |
-| nthArg | 40 B | 633 B | -593 B |
+| nthArg | 55 B | 633 B | -578 B |
 | objOf | 90 B | 240 B | -150 B |
 | of | 29 B | 151 B | -122 B |
 | omit | 129 B | 285 B | -156 B |

--- a/lib/nth/index.js
+++ b/lib/nth/index.js
@@ -1,0 +1,8 @@
+import _curry2 from '../_internal/_curry2'
+
+export default _curry2(function nth(n, list) {
+  var idx = n < 0 ? list.length + n : n
+  return typeof list === 'string' && !list[idx]
+    ? ''
+    : list[idx]
+})

--- a/lib/nth/nth.test.js
+++ b/lib/nth/nth.test.js
@@ -1,0 +1,15 @@
+import nth from '.'
+
+test('returns the nth element of the given list or string', () => {
+  expect(nth(2, 'abc')).toBe('c')
+  expect(nth(2, [1, 2, 3])).toBe(3)
+})
+
+test('returns empty string or undefined for string and array accordingly if index more than item length', () => {
+  expect(nth(3, 'abc')).toBe('')
+  expect(nth(3, [1, 2, 3])).toBeUndefined()
+})
+
+test('if index is negative, length + n item returns', () => {
+  expect(nth(-1, [1, 2, 3])).toBe(3)
+})

--- a/lib/nthArg/index.js
+++ b/lib/nthArg/index.js
@@ -1,0 +1,7 @@
+export default function nthArg(n) {
+  return function() {
+    return n < 0
+      ? arguments[arguments.length + n]
+      : arguments[n]
+  }
+}

--- a/lib/nthArg/nthArg.test.js
+++ b/lib/nthArg/nthArg.test.js
@@ -1,0 +1,9 @@
+import nthArg from '.'
+
+test('returns function, that returns its nth argument', () => {
+  expect(nthArg(1)('a', 'b', 'c')).toBe('b')
+})
+
+test('if index is negative, returns items from the end', () => {
+  expect(nthArg(-1)('a', 'b', 'c')).toBe('c')
+})


### PR DESCRIPTION
[Ramda nth](http://ramdajs.com/docs/#nth)
[Ramda nthArg](http://ramdajs.com/docs/#nthArg)

As I see, ramda's `nthArg` method is only curried, does not support single call, such as `nthArg(n, 'a', 'b')`