### PR TITLE
New method: uncurryN (Size: 132 B)

### DIFF
--- a/SIZES.md
+++ b/SIZES.md
@@ -233,6 +233,7 @@
 | type | 109 B | 186 B | -77 B |
 | unapply | 112 B | 161 B | -49 B |
 | unary | 35 B | 430 B | -395 B |
+| uncurryN | 132 B | 618 B | -486 B |
 | unfold | 110 B | 266 B | -156 B |
 | union | 315 B | 2988 B | -2673 B |
 | unionWith | 134 B | 504 B | -370 B |

--- a/lib/uncurryN/index.js
+++ b/lib/uncurryN/index.js
@@ -3,10 +3,9 @@ import _curry2 from "../_internal/_curry2"
 export default _curry2(function uncurryN(n, cb) {
   return function curried() {
     var res = cb
-    for (var i in arguments) {
-      if (i >= n) return res
+    for (var i = 0; i < n; i++) {
       res = res(arguments[i])
     }
-    return arguments.length < n ? uncurryN(n - arguments.length, res) : res
+    return res
   }
 })

--- a/lib/uncurryN/index.js
+++ b/lib/uncurryN/index.js
@@ -1,0 +1,12 @@
+import _curry2 from "../_internal/_curry2"
+
+export default _curry2(function uncurryN(n, cb) {
+  return function curried() {
+    var res = cb
+    for (var i in arguments) {
+      if (i >= n) return res
+      res = res(arguments[i])
+    }
+    return arguments.length < n ? uncurryN(n - arguments.length, res) : res
+  }
+})

--- a/lib/uncurryN/uncurryN.test.js
+++ b/lib/uncurryN/uncurryN.test.js
@@ -1,0 +1,11 @@
+import uncurryN from "."
+
+test("uncurries function with N args", () => {
+  const sum = a => b => c => d => a + b + c + d
+  expect(uncurryN(4, sum)(1, 2, 3, 4)).toBe(10)
+})
+
+test("does not accept extra args", () => {
+  const sum = a => b => c => d => a + b + c + d
+  expect(uncurryN(4, sum)(1, 2, 3, 4, 5)).toBe(10)
+})


### PR DESCRIPTION
[`R.uncurryN`](http://ramdajs.com/docs/#uncurryN)  
Any ideas how to get rid of [**this line**](https://github.com/nanoutils/nanoutils/pull/94/files#diff-b281c6a09d551677cedbe3d5f194e1b6R10)?
