### PR TITLE
lens method IE compatible

### DIFF
--- a/lib/lens/index.js
+++ b/lib/lens/index.js
@@ -1,10 +1,10 @@
 export default function lens(getter, setter) {
   return function(v) {
     return {
-      get() {
+      get: function() {
         return getter(v)
       },
-      set(val) {
+      set: function(val) {
         return setter(val, v)
       }
     }


### PR DESCRIPTION
This pull request fix a problem using nanoutils with IE11.