### PR TITLE
Update outdated LICENSE year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2017 Anton Kosykh
+Copyright (c) 2017-present Anton Kosykh
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
With this update, you won't care about any further license year updates

Using present instead of the second year is a common pattern, here are some examples

https://github.com/babel/babel/blob/4fb29a372b18e82ba72262db43b80b220a5cce01/LICENSE#L3 https://github.com/reduxjs/redux/blob/8ad084251a5b3e4617157fc52795b6284e68bc1e/LICENSE.md?plain=1#L3 https://github.com/pmndrs/react-spring/blob/e7d423cde197db9d53a00f96422c6d7f8ce12b29/LICENSE#L3 https://github.com/vercel/styled-jsx/blob/e8245813f9c3e633a9b2d2414fb11e6386b31216/license.md?plain=1#L3 https://github.com/styled-components/styled-components/blob/09929bd9bc05da085206c94679f07597b46212e4/LICENSE#L3